### PR TITLE
Use coal ComputeDistance for faster distance calculation

### DIFF
--- a/include/colmpc/residual-distance-collision.hpp
+++ b/include/colmpc/residual-distance-collision.hpp
@@ -137,10 +137,22 @@ struct ResidualDataDistanceCollisionTpl
   typedef typename MathBase::Vector3s Vector3s;
 
   template <template <typename Scalar> class Model>
+  static coal::ComputeDistance buildComputeDistance(Model<Scalar> *const model) {
+    const pinocchio::GeometryModel& geom_model = model->get_geometry();
+    const pinocchio::PairIndex pair_id = model->get_pair_id();
+
+    const auto& cp = geom_model.collisionPairs[pair_id];
+    const auto& geom_1 = geom_model.geometryObjects[cp.first].geometry;
+    const auto& geom_2 = geom_model.geometryObjects[cp.second].geometry;
+
+    return hpp::fcl::ComputeDistance(geom_1.get(), geom_2.get());
+  }
+
+  template <template <typename Scalar> class Model>
   ResidualDataDistanceCollisionTpl(Model<Scalar> *const model,
                                    DataCollectorAbstract *const data)
       : Base(model, data),
-        geometry(pinocchio::GeometryData(model->get_geometry())),
+        distance(buildComputeDistance(model)),
         req(),
         res(),
         J1(6, model->get_state()->get_nv()),
@@ -163,12 +175,15 @@ struct ResidualDataDistanceCollisionTpl
     f1p1.fill(0);
     f2p2.fill(0);
   }
-  pinocchio::GeometryData geometry;       //!< Pinocchio geometry data
   pinocchio::DataTpl<Scalar> *pinocchio;  //!< Pinocchio data
   using Base::r;
   using Base::Ru;
   using Base::Rx;
   using Base::shared;
+
+  hpp::fcl::ComputeDistance
+      distance; //!< Compute Distance from hppfcl,
+                //!< used to compute the distance between shapes
 
   hpp::fcl::DistanceRequest
       req;  //!< Distance Request from hppfcl,

--- a/include/colmpc/residual-distance-collision.hxx
+++ b/include/colmpc/residual-distance-collision.hxx
@@ -61,9 +61,10 @@ void ResidualDistanceCollisionTpl<Scalar>::calc(
     d->oMg_id_2 = geom_2.placement;
   }
 
-  d->r[0] = hpp::fcl::distance(
-      geom_1.geometry.get(), toFclTransform3f(d->oMg_id_1),
-      geom_2.geometry.get(), toFclTransform3f(d->oMg_id_2), d->req, d->res);
+  d->r[0] = d->distance(toFclTransform3f(d->oMg_id_1),
+                        toFclTransform3f(d->oMg_id_2),
+                        d->req,
+                        d->res);
 }
 
 template <typename Scalar>

--- a/python/residual-distance-collision.cpp
+++ b/python/residual-distance-collision.cpp
@@ -74,10 +74,6 @@ void exposeResidualDistanceCollision() {
           ":param model: pair collision residual model\n"
           ":param data: shared data")[bp::with_custodian_and_ward<
           1, 2, bp::with_custodian_and_ward<1, 3>>()])
-      .add_property("geometry",
-                    bp::make_getter(&ResidualDataDistanceCollision::geometry,
-                                    bp::return_internal_reference<>()),
-                    "pinocchio geometry data")
       .add_property("pinocchio",
                     bp::make_getter(&ResidualDataDistanceCollision::pinocchio,
                                     bp::return_internal_reference<>()),


### PR DESCRIPTION
Using `coal::ComputeDistance` is faster than using `coal::distance` for repeated calls.