### PR TITLE
Move from `boost` pointer to `std` pointer

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,29 @@
 {
   "nodes": {
+    "crocoddyl": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1738932671,
+        "narHash": "sha256-2xceLlDCaUxUWMoCZralxsBwxwBc2jhNK7iqccIz7rU=",
+        "owner": "loco-3d",
+        "repo": "crocoddyl",
+        "rev": "871b0a933f1f74f0abb8bbbce0d367c769eeb435",
+        "type": "github"
+      },
+      "original": {
+        "owner": "loco-3d",
+        "ref": "release/3.0.0",
+        "repo": "crocoddyl",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -48,6 +72,7 @@
     },
     "root": {
       "inputs": {
+        "crocoddyl": "crocoddyl",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1738453229,
+        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733759999,
-        "narHash": "sha256-463SNPWmz46iLzJKRzO3Q2b0Aurff3U1n0nYItxq7jU=",
+        "lastModified": 1737885589,
+        "narHash": "sha256-Zf0hSrtzaM1DEz8//+Xs51k/wdSajticVrATqDrfQjg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a73246e2eef4c6ed172979932bc80e1404ba2d56",
+        "rev": "852ff1d9e153d8875a83602e03fdef8a63f0ecf8",
         "type": "github"
       },
       "original": {
@@ -60,14 +60,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1733096140,
-        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
+        "lastModified": 1738452942,
+        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,15 +23,12 @@
           _module.args.pkgs = import inputs.nixpkgs {
             inherit system;
             overlays = [
-              (_final: prev: {
+              (_final: _prev: {
                 # Get pinocchio with #2566 until pinocchio > 3.3.1
                 # to fix crocoddyl python imports on macos
-                inherit (inputs.crocoddyl.packages.${system}) pinocchio;
-                # Get croddyl with #1339
+                # And croddyl with #1339
                 # to have std::shared_ptr
-                crocoddyl = prev.crocoddyl.overrideAttrs {
-                  inherit (inputs.crocoddyl.packages.${system}.crocoddyl) src;
-                };
+                inherit (inputs.crocoddyl.packages.${system}) crocoddyl pinocchio;
               })
             ];
           };

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,13 @@
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    # override for boost -> std shared_ptr
+    crocoddyl = {
+      url = "github:loco-3d/crocoddyl/release/3.0.0";
+      inputs.flake-parts.follows = "flake-parts";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -11,8 +18,23 @@
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = inputs.nixpkgs.lib.systems.flakeExposed;
       perSystem =
-        { pkgs, self', ... }:
+        { pkgs, self', system, ... }:
         {
+          _module.args.pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [
+              (_final: prev: {
+                # Get pinocchio with #2566 until pinocchio > 3.3.1
+                # to fix crocoddyl python imports on macos
+                inherit (inputs.crocoddyl.packages.${system}) pinocchio;
+                # Get croddyl with #1339
+                # to have std::shared_ptr
+                crocoddyl = prev.crocoddyl.overrideAttrs {
+                  inherit (inputs.crocoddyl.packages.${system}.crocoddyl) src;
+                };
+              })
+            ];
+          };
           apps.default = {
             type = "app";
             program = pkgs.python3.withPackages (_: [ self'.packages.default ]);

--- a/include/colmpc/quadratic-exp.hpp
+++ b/include/colmpc/quadratic-exp.hpp
@@ -69,14 +69,14 @@ class ActivationModelQuadExpTpl : public ActivationModelAbstractTpl<_Scalar> {
    * @param[in] data  Quadratic activation data
    * @param[in] r     Residual vector \f$\mathbf{r}\in\mathbb{R}^{nr}\f$
    */
-  virtual void calc(const boost::shared_ptr<ActivationDataAbstract> &data,
+  virtual void calc(const std::shared_ptr<ActivationDataAbstract> &data,
                     const Eigen::Ref<const VectorXs> &r) {
     if (static_cast<std::size_t>(r.size()) != nr_) {
       throw_pretty(
           "Invalid argument: " << "r has wrong dimension (it should be " +
                                       std::to_string(nr_) + ")");
     }
-    boost::shared_ptr<Data> d = boost::static_pointer_cast<Data>(data);
+    std::shared_ptr<Data> d = std::static_pointer_cast<Data>(data);
 
     data->a_value = exp(-r.squaredNorm() / alpha_);
   };
@@ -87,14 +87,14 @@ class ActivationModelQuadExpTpl : public ActivationModelAbstractTpl<_Scalar> {
    * @param[in] data  Quadratic activation data
    * @param[in] r     Residual vector \f$\mathbf{r}\in\mathbb{R}^{nr}\f$
    */
-  virtual void calcDiff(const boost::shared_ptr<ActivationDataAbstract> &data,
+  virtual void calcDiff(const std::shared_ptr<ActivationDataAbstract> &data,
                         const Eigen::Ref<const VectorXs> &r) {
     if (static_cast<std::size_t>(r.size()) != nr_) {
       throw_pretty(
           "Invalid argument: " << "r has wrong dimension (it should be " +
                                       std::to_string(nr_) + ")");
     }
-    boost::shared_ptr<Data> d = boost::static_pointer_cast<Data>(data);
+    std::shared_ptr<Data> d = std::static_pointer_cast<Data>(data);
 
     d->a1 = -Scalar(2.0) / alpha_ * d->a_value;
     data->Ar = d->a1 * r;
@@ -107,9 +107,9 @@ class ActivationModelQuadExpTpl : public ActivationModelAbstractTpl<_Scalar> {
    *
    * @return the activation data
    */
-  virtual boost::shared_ptr<ActivationDataAbstract> createData() {
-    boost::shared_ptr<Data> data =
-        boost::allocate_shared<Data>(Eigen::aligned_allocator<Data>(), this);
+  virtual std::shared_ptr<ActivationDataAbstract> createData() {
+    std::shared_ptr<Data> data =
+        std::allocate_shared<Data>(Eigen::aligned_allocator<Data>(), this);
     return data;
   };
 

--- a/include/colmpc/residual-distance-collision.hpp
+++ b/include/colmpc/residual-distance-collision.hpp
@@ -55,9 +55,9 @@ struct ResidualDistanceCollisionTpl : public ResidualModelAbstractTpl<_Scalar> {
    * @param[in] pair_id     Index of the collision pair in the geometry model
    */
 
-  ResidualDistanceCollisionTpl(boost::shared_ptr<StateMultibody> state,
+  ResidualDistanceCollisionTpl(std::shared_ptr<StateMultibody> state,
                                const std::size_t nu,
-                               boost::shared_ptr<GeometryModel> geom_model,
+                               std::shared_ptr<GeometryModel> geom_model,
                                const pinocchio::PairIndex pair_id);
   virtual ~ResidualDistanceCollisionTpl();
 
@@ -68,7 +68,7 @@ struct ResidualDistanceCollisionTpl : public ResidualModelAbstractTpl<_Scalar> {
    * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
    * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
    */
-  virtual void calc(const boost::shared_ptr<ResidualDataAbstract> &data,
+  virtual void calc(const std::shared_ptr<ResidualDataAbstract> &data,
                     const Eigen::Ref<const VectorXs> &x,
                     const Eigen::Ref<const VectorXs> &u);
 
@@ -79,11 +79,11 @@ struct ResidualDistanceCollisionTpl : public ResidualModelAbstractTpl<_Scalar> {
    * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
    * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
    */
-  virtual void calcDiff(const boost::shared_ptr<ResidualDataAbstract> &data,
+  virtual void calcDiff(const std::shared_ptr<ResidualDataAbstract> &data,
                         const Eigen::Ref<const VectorXs> &x,
                         const Eigen::Ref<const VectorXs> &u);
 
-  virtual boost::shared_ptr<ResidualDataAbstract> createData(
+  virtual std::shared_ptr<ResidualDataAbstract> createData(
       DataCollectorAbstract *const data);
 
   /**
@@ -110,7 +110,7 @@ struct ResidualDistanceCollisionTpl : public ResidualModelAbstractTpl<_Scalar> {
  private:
   typename StateMultibody::PinocchioModel
       pin_model_;  //!< Pinocchio model used for internal computations
-  boost::shared_ptr<pinocchio::GeometryModel>
+  std::shared_ptr<pinocchio::GeometryModel>
       geom_model_;  //!< Pinocchio geometry model containing collision pair
   pinocchio::PairIndex
       pair_id_;  //!< Index of the collision pair in geometry model

--- a/include/colmpc/residual-distance-collision.hxx
+++ b/include/colmpc/residual-distance-collision.hxx
@@ -15,8 +15,8 @@ using namespace crocoddyl;
 
 template <typename Scalar>
 ResidualDistanceCollisionTpl<Scalar>::ResidualDistanceCollisionTpl(
-    boost::shared_ptr<StateMultibody> state, const std::size_t nu,
-    boost::shared_ptr<GeometryModel> geom_model,
+    std::shared_ptr<StateMultibody> state, const std::size_t nu,
+    std::shared_ptr<GeometryModel> geom_model,
     const pinocchio::PairIndex pair_id)
     : Base(state, 1, nu, true, false, false),
       pin_model_(*state->get_pinocchio()),
@@ -35,7 +35,7 @@ ResidualDistanceCollisionTpl<Scalar>::~ResidualDistanceCollisionTpl() {}
 
 template <typename Scalar>
 void ResidualDistanceCollisionTpl<Scalar>::calc(
-    const boost::shared_ptr<ResidualDataAbstract> &data,
+    const std::shared_ptr<ResidualDataAbstract> &data,
     const Eigen::Ref<const VectorXs> &x, const Eigen::Ref<const VectorXs> &) {
   Data *d = static_cast<Data *>(data.get());
 
@@ -67,7 +67,7 @@ void ResidualDistanceCollisionTpl<Scalar>::calc(
 
 template <typename Scalar>
 void ResidualDistanceCollisionTpl<Scalar>::calcDiff(
-    const boost::shared_ptr<ResidualDataAbstract> &data,
+    const std::shared_ptr<ResidualDataAbstract> &data,
     const Eigen::Ref<const VectorXs> &x, const Eigen::Ref<const VectorXs> &) {
   Data *d = static_cast<Data *>(data.get());
 
@@ -109,11 +109,11 @@ void ResidualDistanceCollisionTpl<Scalar>::calcDiff(
       (d->J1.template topRows<3>() - d->J2.template topRows<3>());
 }
 template <typename Scalar>
-boost::shared_ptr<ResidualDataAbstractTpl<Scalar> >
+std::shared_ptr<ResidualDataAbstractTpl<Scalar> >
 ResidualDistanceCollisionTpl<Scalar>::createData(
     DataCollectorAbstract *const data) {
-  return boost::allocate_shared<Data>(Eigen::aligned_allocator<Data>(), this,
-                                      data);
+  return std::allocate_shared<Data>(Eigen::aligned_allocator<Data>(), this,
+                                    data);
 }
 
 template <typename Scalar>

--- a/include/colmpc/residual-velocity-avoidance.hpp
+++ b/include/colmpc/residual-velocity-avoidance.hpp
@@ -73,8 +73,8 @@ struct ResidualModelVelocityAvoidanceTpl
    * @param[in] ksi         Convergence speed coefficient
    */
 
-  ResidualModelVelocityAvoidanceTpl(boost::shared_ptr<StateMultibody> state,
-                                    boost::shared_ptr<GeometryModel> geom_model,
+  ResidualModelVelocityAvoidanceTpl(std::shared_ptr<StateMultibody> state,
+                                    std::shared_ptr<GeometryModel> geom_model,
                                     const pinocchio::PairIndex pair_id,
                                     const Scalar di = 1.0e-2,
                                     const Scalar ds = 1.0e-5,
@@ -87,7 +87,7 @@ struct ResidualModelVelocityAvoidanceTpl
    * @param[in] data  Pair collision residual data
    * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
    */
-  virtual void calc(const boost::shared_ptr<ResidualDataAbstract> &data,
+  virtual void calc(const std::shared_ptr<ResidualDataAbstract> &data,
                     const Eigen::Ref<const VectorXs> &x,
                     const Eigen::Ref<const VectorXs> &u);
 
@@ -97,11 +97,11 @@ struct ResidualModelVelocityAvoidanceTpl
    * @param[in] data  Pair collision residual data
    * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
    */
-  virtual void calcDiff(const boost::shared_ptr<ResidualDataAbstract> &data,
+  virtual void calcDiff(const std::shared_ptr<ResidualDataAbstract> &data,
                         const Eigen::Ref<const VectorXs> &x,
                         const Eigen::Ref<const VectorXs> &u);
 
-  virtual boost::shared_ptr<ResidualDataAbstract> createData(
+  virtual std::shared_ptr<ResidualDataAbstract> createData(
       DataCollectorAbstract *const data);
 
   /**
@@ -165,7 +165,7 @@ struct ResidualModelVelocityAvoidanceTpl
 
   typename StateMultibody::PinocchioModel
       pin_model_;  //!< Pinocchio model used for internal computations
-  boost::shared_ptr<GeometryModel>
+  std::shared_ptr<GeometryModel>
       geom_model_;  //!< Pinocchio geometry model containing collision pair
   pinocchio::PairIndex
       pair_id_;  //!< Index of the collision pair in geometry model

--- a/include/colmpc/residual-velocity-avoidance.hxx
+++ b/include/colmpc/residual-velocity-avoidance.hxx
@@ -22,8 +22,8 @@ using namespace crocoddyl;
 
 template <typename Scalar>
 ResidualModelVelocityAvoidanceTpl<Scalar>::ResidualModelVelocityAvoidanceTpl(
-    boost::shared_ptr<StateMultibody> state,
-    boost::shared_ptr<GeometryModel> geom_model,
+    std::shared_ptr<StateMultibody> state,
+    std::shared_ptr<GeometryModel> geom_model,
     const pinocchio::PairIndex pair_id, const Scalar di, const Scalar ds,
     const Scalar ksi)
     : Base(state, 1, true, true, true),
@@ -50,7 +50,7 @@ ResidualModelVelocityAvoidanceTpl<
 
 template <typename Scalar>
 void ResidualModelVelocityAvoidanceTpl<Scalar>::calc(
-    const boost::shared_ptr<ResidualDataAbstract> &data,
+    const std::shared_ptr<ResidualDataAbstract> &data,
     const Eigen::Ref<const VectorXs> &, const Eigen::Ref<const VectorXs> &) {
   Data *d = static_cast<Data *>(data.get());
 
@@ -118,7 +118,7 @@ void ResidualModelVelocityAvoidanceTpl<Scalar>::calc(
 
 template <typename Scalar>
 void ResidualModelVelocityAvoidanceTpl<Scalar>::calcDiff(
-    const boost::shared_ptr<ResidualDataAbstract> &data,
+    const std::shared_ptr<ResidualDataAbstract> &data,
     const Eigen::Ref<const VectorXs> &x, const Eigen::Ref<const VectorXs> &) {
   Data *d = static_cast<Data *>(data.get());
 
@@ -318,11 +318,11 @@ void ResidualModelVelocityAvoidanceTpl<Scalar>::calcDiff(
   data->Rx = d->ddistdot_dq_val.transpose();
 }
 template <typename Scalar>
-boost::shared_ptr<ResidualDataAbstractTpl<Scalar> >
+std::shared_ptr<ResidualDataAbstractTpl<Scalar> >
 ResidualModelVelocityAvoidanceTpl<Scalar>::createData(
     DataCollectorAbstract *const data) {
-  return boost::allocate_shared<Data>(Eigen::aligned_allocator<Data>(), this,
-                                      data);
+  return std::allocate_shared<Data>(Eigen::aligned_allocator<Data>(), this,
+                                    data);
 }
 
 template <typename Scalar>

--- a/python/quadratic-exp.cpp
+++ b/python/quadratic-exp.cpp
@@ -16,7 +16,7 @@ namespace python {
 namespace bp = boost::python;
 
 void exposeActivationModelQuadExp() {
-  bp::register_ptr_to_python<boost::shared_ptr<ActivationModelQuadExp> >();
+  bp::register_ptr_to_python<std::shared_ptr<ActivationModelQuadExp> >();
 
   bp::class_<ActivationModelQuadExp,
              bp::bases<crocoddyl::ActivationModelAbstract> >(

--- a/python/residual-distance-collision.cpp
+++ b/python/residual-distance-collision.cpp
@@ -14,12 +14,12 @@ namespace python {
 namespace bp = boost::python;
 
 void exposeResidualDistanceCollision() {
-  bp::register_ptr_to_python<boost::shared_ptr<ResidualDistanceCollision>>();
+  bp::register_ptr_to_python<std::shared_ptr<ResidualDistanceCollision>>();
 
   bp::class_<ResidualDistanceCollision, bp::bases<ResidualModelAbstract>>(
       "ResidualDistanceCollision",
-      bp::init<boost::shared_ptr<StateMultibody>, const std::size_t,
-               boost::shared_ptr<pinocchio::GeometryModel>,
+      bp::init<std::shared_ptr<StateMultibody>, const std::size_t,
+               std::shared_ptr<pinocchio::GeometryModel>,
                const pinocchio::PairIndex>(
           bp::args("self", "state", "nu", "geom_model", "pair_id"),
           "Initialize the residual model.\n\n"
@@ -63,8 +63,7 @@ void exposeResidualDistanceCollision() {
           bp::make_function(&ResidualDistanceCollision::set_pair_id),
           "reference collision pair id");
 
-  bp::register_ptr_to_python<
-      boost::shared_ptr<ResidualDataDistanceCollision>>();
+  bp::register_ptr_to_python<std::shared_ptr<ResidualDataDistanceCollision>>();
 
   bp::class_<ResidualDataDistanceCollision, bp::bases<ResidualDataAbstract>>(
       "ResidualDataDistanceCollision", "Data for vel collision residual.\n\n",

--- a/python/residual-velocity-avoidance.cpp
+++ b/python/residual-velocity-avoidance.cpp
@@ -14,13 +14,12 @@ namespace python {
 namespace bp = boost::python;
 
 void exposeResidualVelocityAvoidance() {
-  bp::register_ptr_to_python<
-      boost::shared_ptr<ResidualModelVelocityAvoidance>>();
+  bp::register_ptr_to_python<std::shared_ptr<ResidualModelVelocityAvoidance>>();
 
   bp::class_<ResidualModelVelocityAvoidance, bp::bases<ResidualModelAbstract>>(
       "ResidualModelVelocityAvoidance",
-      bp::init<boost::shared_ptr<StateMultibody>,
-               boost::shared_ptr<pinocchio::GeometryModel>,
+      bp::init<std::shared_ptr<StateMultibody>,
+               std::shared_ptr<pinocchio::GeometryModel>,
                const pinocchio::PairIndex,
                bp::optional<const double, const double, const double>>(
           bp::args("self", "state", "geom_model", "pair_id", "di", "ds", "ksi"),
@@ -85,8 +84,7 @@ void exposeResidualVelocityAvoidance() {
           bp::make_function(&ResidualModelVelocityAvoidance::set_ksi),
           "reference convergence speed coefficient");
 
-  bp::register_ptr_to_python<
-      boost::shared_ptr<ResidualDataVelocityAvoidance>>();
+  bp::register_ptr_to_python<std::shared_ptr<ResidualDataVelocityAvoidance>>();
 
   bp::class_<ResidualDataVelocityAvoidance, bp::bases<ResidualDataAbstract>>(
       "ResidualDataVelocityAvoidance", "Data for vel collision residual.\n\n",


### PR DESCRIPTION
In order to keep up with the latest changes in Crocoddyl I am updating this repo to use `std::shared_ptr` instead of `boost::shared_ptr`.