### PR TITLE
Add distance residual with centralized calculations

### DIFF
--- a/examples/create_ocp.py
+++ b/examples/create_ocp.py
@@ -269,6 +269,142 @@ def create_ocp_distance(
     return ocp, objects
 
 
+def create_ocp_distance_2(
+    rmodel: pin.Model,
+    gmodel: pin.GeometryModel,
+    use_distance_in_cost: bool,
+    param_parser: ParamParser,
+) -> crocoddyl.SolverAbstract:
+    objects = {}
+
+    # Stat and actuation model
+    state = col.StateMultibody(rmodel, gmodel)
+    actuation = crocoddyl.ActuationModelFull(state)
+
+    # Running & terminal cost models
+    runningCostModel = crocoddyl.CostModelSum(state)
+    terminalCostModel = crocoddyl.CostModelSum(state)
+
+    ### Creation of cost terms
+
+    # State Regularization cost
+    xResidual = crocoddyl.ResidualModelState(state, param_parser.get_X0())
+    xRegCost = crocoddyl.CostModelResidual(state, xResidual)
+
+    # Control Regularization cost
+    uResidual = crocoddyl.ResidualModelControl(state)
+    uRegCost = crocoddyl.CostModelResidual(state, uResidual)
+
+    # End effector frame cost
+    framePlacementResidual = crocoddyl.ResidualModelFramePlacement(
+        state,
+        rmodel.getFrameId("panda2_hand_tcp"),
+        param_parser.get_target_pose(),
+    )
+    objects["framePlacementResidual"] = framePlacementResidual
+
+    goalTrackingCost = crocoddyl.CostModelResidual(state, framePlacementResidual)
+
+    # Obstacle cost with hard constraint
+    runningConstraintModelManager = crocoddyl.ConstraintModelManager(
+        state, actuation.nu
+    )
+    terminalConstraintModelManager = crocoddyl.ConstraintModelManager(
+        state, actuation.nu
+    )
+    # Creating the residual
+
+    for col_idx, _ in enumerate(gmodel.collisionPairs):
+        obstacleDistanceResidual = col.ResidualDistanceCollision2(state, 7, col_idx)
+        # Creating the inequality constraint
+        constraint = crocoddyl.ConstraintModelResidual(
+            state,
+            obstacleDistanceResidual,
+            np.array([param_parser.get_safety_threshold()]),
+            np.array([np.inf]),
+        )
+
+        # Adding the constraint to the constraint manager
+        runningConstraintModelManager.addConstraint(f"col_{col_idx}", constraint)
+        terminalConstraintModelManager.addConstraint(f"col_term_{col_idx}", constraint)
+
+        if use_distance_in_cost:
+            # Add the distance residual to the cost
+            assert obstacleDistanceResidual.nr == 1
+            # activation = col.ActivationModelQuadExp(
+            #     1, param_parser.get_distance_threshold()
+            # )
+            activation = col.ActivationModelExp(
+                1, param_parser.get_distance_threshold()
+            )
+            # activation = col.ActivationModelDistanceQuad(
+            #     1, param_parser.get_distance_threshold()
+            # )
+            cost = crocoddyl.CostModelResidual(
+                state, activation, obstacleDistanceResidual
+            )
+            runningCostModel.addCost(
+                f"col_{col_idx}", cost, param_parser.get_W_obstacle()
+            )
+            terminalCostModel.addCost(
+                f"col_term_{col_idx}", cost, param_parser.get_W_obstacle()
+            )
+
+    # Adding costs to the models
+    runningCostModel.addCost("stateReg", xRegCost, param_parser.get_W_xREG())
+    runningCostModel.addCost("ctrlRegGrav", uRegCost, param_parser.get_W_uREG())
+    runningCostModel.addCost(
+        "gripperPoseRM", goalTrackingCost, param_parser.get_W_gripper_pose()
+    )
+    terminalCostModel.addCost("stateReg", xRegCost, param_parser.get_W_xREG())
+    terminalCostModel.addCost(
+        "gripperPose", goalTrackingCost, param_parser.get_W_gripper_pose_term()
+    )
+
+    # Create Differential Action Model (DAM),
+    # i.e. continuous dynamics and cost functions
+    running_DAM = col.DifferentialActionModelFreeFwdDynamics(
+        state,
+        actuation,
+        runningCostModel,
+        runningConstraintModelManager,
+    )
+    terminal_DAM = col.DifferentialActionModelFreeFwdDynamics(
+        state,
+        actuation,
+        terminalCostModel,
+        terminalConstraintModelManager,
+    )
+
+    runningModel = crocoddyl.IntegratedActionModelEuler(
+        running_DAM, param_parser.get_dt()
+    )
+    terminalModel = crocoddyl.IntegratedActionModelEuler(terminal_DAM, 0.0)
+
+    runningModel.differential.armature = np.full(7, 0.1)
+    terminalModel.differential.armature = np.full(7, 0.1)
+
+    problem = crocoddyl.ShootingProblem(
+        param_parser.get_X0(), [runningModel] * param_parser.get_T(), terminalModel
+    )
+    # Create solver + callbacks
+    # Define mim solver with inequalities constraints
+    ocp = mim_solvers.SolverCSQP(problem)
+
+    # Merit function
+    ocp.use_filter_line_search = False
+
+    # Parameters of the solver
+    ocp.termination_tolerance = 1e-3
+    ocp.max_qp_iters = 1000
+    ocp.eps_abs = 1e-6
+    ocp.eps_rel = 0
+
+    ocp.with_callbacks = True
+
+    return ocp, objects
+
+
 def create_ocp_nocol(
     rmodel: pin.Model, param_parser: ParamParser
 ) -> crocoddyl.SolverAbstract:

--- a/examples/main_ocp_interactive.py
+++ b/examples/main_ocp_interactive.py
@@ -81,7 +81,7 @@ if args.velocity:
     ocp, objects = create_ocp.create_ocp_velocity(rmodel, cmodel, pp)
 else:
     # OCP with distance constraints
-    ocp, objects = create_ocp.create_ocp_distance(
+    ocp, objects = create_ocp.create_ocp_distance_2(
         rmodel, cmodel, args.distance_in_cost, pp
     )
 

--- a/include/colmpc/data/geometry-data.hpp
+++ b/include/colmpc/data/geometry-data.hpp
@@ -1,0 +1,17 @@
+#include <pinocchio/multibody/geometry.hpp>
+
+namespace colmpc {
+
+struct GeometryDataWrapper {
+  pinocchio::GeometryData *geometry = nullptr;
+
+  void setGeometry(pinocchio::GeometryData *g) {
+    if (geometry != nullptr && g != geometry) {
+      // This is not strictly required. However, setting the geom data twice
+      // might indicate a bug.
+      throw std::invalid_argument("Cannot set twice geometry data.");
+    }
+    geometry = g;
+  }
+};
+}  // namespace colmpc

--- a/include/colmpc/free-fwddyn.hpp
+++ b/include/colmpc/free-fwddyn.hpp
@@ -1,0 +1,117 @@
+#ifndef COLMPC_ACTIONS_FREE_FWDDYN_HPP_
+#define COLMPC_ACTIONS_FREE_FWDDYN_HPP_
+
+#include <stdexcept>
+
+#ifdef PINOCCHIO_WITH_CPPAD_SUPPORT  // TODO(cmastalli): Removed after merging
+                                     // Pinocchio v.2.4.8
+#include <pinocchio/codegen/cppadcg.hpp>
+#endif
+
+#include "colmpc/data/geometry-data.hpp"
+#include "colmpc/multibody.hpp"
+#include "crocoddyl/multibody/actions/free-fwddyn.hpp"
+
+namespace colmpc {
+
+template <typename _Scalar>
+class DifferentialActionModelFreeFwdDynamicsTpl
+    : public crocoddyl::DifferentialActionModelFreeFwdDynamicsTpl<_Scalar> {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef crocoddyl::DifferentialActionModelFreeFwdDynamicsTpl<Scalar> Base;
+  typedef DifferentialActionDataFreeFwdDynamicsTpl<Scalar> Data;
+  typedef crocoddyl::DifferentialActionDataAbstractTpl<Scalar>
+      DifferentialActionDataAbstract;
+  typedef StateMultibodyTpl<Scalar> StateMultibody;
+  typedef crocoddyl::CostModelSumTpl<Scalar> CostModelSum;
+  typedef crocoddyl::ConstraintModelManagerTpl<Scalar> ConstraintModelManager;
+  typedef crocoddyl::ActuationModelAbstractTpl<Scalar> ActuationModelAbstract;
+  typedef crocoddyl::MathBaseTpl<Scalar> MathBase;
+  typedef typename MathBase::VectorXs VectorXs;
+  typedef typename MathBase::MatrixXs MatrixXs;
+
+  DifferentialActionModelFreeFwdDynamicsTpl(
+      std::shared_ptr<StateMultibody> state,
+      std::shared_ptr<ActuationModelAbstract> actuation,
+      std::shared_ptr<CostModelSum> costs,
+      std::shared_ptr<ConstraintModelManager> constraints = nullptr);
+  virtual ~DifferentialActionModelFreeFwdDynamicsTpl();
+
+  /**
+   * @brief Compute the system acceleration, and cost value
+   *
+   * It computes the system acceleration using the free forward-dynamics.
+   *
+   * @param[in] data  Free forward-dynamics data
+   * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
+   * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
+   */
+  virtual void calc(const std::shared_ptr<DifferentialActionDataAbstract>& data,
+                    const Eigen::Ref<const VectorXs>& x,
+                    const Eigen::Ref<const VectorXs>& u);
+
+  /**
+   * @brief @copydoc Base::calc(const
+   * std::shared_ptr<DifferentialActionDataAbstract>& data, const
+   * Eigen::Ref<const VectorXs>& x)
+   */
+  virtual void calc(const std::shared_ptr<DifferentialActionDataAbstract>& data,
+                    const Eigen::Ref<const VectorXs>& x);
+
+  /**
+   * @brief Create the free forward-dynamics data
+   *
+   * @return free forward-dynamics data
+   */
+  virtual std::shared_ptr<DifferentialActionDataAbstract> createData();
+
+  /**
+   * @brief Check that the given data belongs to the free forward-dynamics data
+   */
+  virtual bool checkData(
+      const std::shared_ptr<DifferentialActionDataAbstract>& data);
+
+  /**
+   * @brief Return the Pinocchio model
+   */
+  inline pinocchio::GeometryModel& get_geometry() const { return geometry_; }
+
+  /**
+   * @brief Print relevant information of the free forward-dynamics model
+   *
+   * @param[out] os  Output stream object
+   */
+  virtual void print(std::ostream& os) const;
+
+ protected:
+  using Base::g_lb_;   //!< Lower bound of the inequality constraints
+  using Base::g_ub_;   //!< Upper bound of the inequality constraints
+  using Base::nu_;     //!< Control dimension
+  using Base::state_;  //!< Model of the state
+
+ private:
+  pinocchio::GeometryModel& geometry_;  //!< Pinocchio model
+};
+
+template <typename _Scalar>
+struct DifferentialActionDataFreeFwdDynamicsTpl
+    : crocoddyl::DifferentialActionDataFreeFwdDynamicsTpl<_Scalar> {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  typedef _Scalar Scalar;
+  typedef crocoddyl::DifferentialActionDataFreeFwdDynamicsTpl<Scalar> Base;
+
+  explicit DifferentialActionDataFreeFwdDynamicsTpl(
+      DifferentialActionModelFreeFwdDynamicsTpl<Scalar>* const model);
+
+  pinocchio::GeometryData geometry;
+};
+
+extern template class DifferentialActionModelFreeFwdDynamicsTpl<double>;
+extern template class DifferentialActionDataFreeFwdDynamicsTpl<double>;
+
+}  // namespace colmpc
+
+#endif  // COLMPC_ACTIONS_FREE_FWDDYN_HPP_

--- a/include/colmpc/free-fwddyn.hxx
+++ b/include/colmpc/free-fwddyn.hxx
@@ -1,0 +1,120 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2019-2024, LAAS-CNRS, University of Edinburgh,
+//                          Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include <crocoddyl/core/utils/exception.hpp>
+#include <pinocchio/collision/distance.hpp>
+
+#include "colmpc/free-fwddyn.hpp"
+
+namespace colmpc {
+
+template <typename Scalar>
+DifferentialActionModelFreeFwdDynamicsTpl<Scalar>::
+    DifferentialActionModelFreeFwdDynamicsTpl(
+        std::shared_ptr<StateMultibody> state,
+        std::shared_ptr<ActuationModelAbstract> actuation,
+        std::shared_ptr<CostModelSum> costs,
+        std::shared_ptr<ConstraintModelManager> constraints)
+    : Base(state, actuation, costs, constraints),
+      geometry_(*state->get_geometry().get()) {}
+
+template <typename Scalar>
+DifferentialActionModelFreeFwdDynamicsTpl<
+    Scalar>::~DifferentialActionModelFreeFwdDynamicsTpl() {}
+
+template <typename Scalar>
+void DifferentialActionModelFreeFwdDynamicsTpl<Scalar>::calc(
+    const std::shared_ptr<DifferentialActionDataAbstract> &data,
+    const Eigen::Ref<const VectorXs> &x, const Eigen::Ref<const VectorXs> &u) {
+  if (static_cast<std::size_t>(x.size()) != state_->get_nx()) {
+    throw_pretty(
+        "Invalid argument: " << "x has wrong dimension (it should be " +
+                                    std::to_string(state_->get_nx()) + ")");
+  }
+  if (static_cast<std::size_t>(u.size()) != nu_) {
+    throw_pretty(
+        "Invalid argument: " << "u has wrong dimension (it should be " +
+                                    std::to_string(nu_) + ")");
+  }
+
+  Data *d = static_cast<Data *>(data.get());
+  const Eigen::VectorBlock<const Eigen::Ref<const VectorXs>, Eigen::Dynamic> q =
+      x.head(state_->get_nq());
+  pinocchio::computeDistances(this->get_pinocchio(), d->pinocchio, geometry_,
+                              d->geometry, q);
+  Base::calc(data, x, u);
+}
+
+template <typename Scalar>
+void DifferentialActionModelFreeFwdDynamicsTpl<Scalar>::calc(
+    const std::shared_ptr<DifferentialActionDataAbstract> &data,
+    const Eigen::Ref<const VectorXs> &x) {
+  if (static_cast<std::size_t>(x.size()) != state_->get_nx()) {
+    throw_pretty(
+        "Invalid argument: " << "x has wrong dimension (it should be " +
+                                    std::to_string(state_->get_nx()) + ")");
+  }
+
+  Data *d = static_cast<Data *>(data.get());
+  const Eigen::VectorBlock<const Eigen::Ref<const VectorXs>, Eigen::Dynamic> q =
+      x.head(state_->get_nq());
+
+  pinocchio::computeDistances(this->get_pinocchio(), d->pinocchio, geometry_,
+                              d->geometry, q);
+  Base::calc(data, x);
+}
+
+template <typename Scalar>
+std::shared_ptr<crocoddyl::DifferentialActionDataAbstractTpl<Scalar>>
+DifferentialActionModelFreeFwdDynamicsTpl<Scalar>::createData() {
+  return std::allocate_shared<Data>(Eigen::aligned_allocator<Data>(), this);
+}
+
+template <typename Scalar>
+bool DifferentialActionModelFreeFwdDynamicsTpl<Scalar>::checkData(
+    const std::shared_ptr<DifferentialActionDataAbstract> &data) {
+  std::shared_ptr<Data> d = std::dynamic_pointer_cast<Data>(data);
+  if (d != NULL) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+template <typename Scalar>
+void DifferentialActionModelFreeFwdDynamicsTpl<Scalar>::print(
+    std::ostream &os) const {
+  os << "DifferentialActionModelFreeFwdDynamics {nx=" << state_->get_nx()
+     << ", ndx=" << state_->get_ndx() << ", nu=" << nu_
+     << ", ncolpairs=" << geometry_.collisionPairs.size() << "}";
+}
+
+template <typename Scalar>
+DifferentialActionDataFreeFwdDynamicsTpl<Scalar>::
+    DifferentialActionDataFreeFwdDynamicsTpl(
+        DifferentialActionModelFreeFwdDynamicsTpl<Scalar> *const model)
+    : Base(model), geometry(model->get_geometry()) {
+  for (auto &name_cost : this->costs->costs) {
+    auto w = std::dynamic_pointer_cast<GeometryDataWrapper>(
+        name_cost.second->residual);
+    if (w) {
+      w->setGeometry(&geometry);
+    }
+  }
+
+  for (auto &name_constraints : this->constraints->constraints) {
+    auto w = std::dynamic_pointer_cast<GeometryDataWrapper>(
+        name_constraints.second->residual);
+    if (w) {
+      w->setGeometry(&geometry);
+    }
+  }
+}
+
+}  // namespace colmpc

--- a/include/colmpc/fwd.hpp
+++ b/include/colmpc/fwd.hpp
@@ -19,12 +19,31 @@ class ResidualDataDistanceCollisionTpl;
 typedef ResidualDataDistanceCollisionTpl<double> ResidualDataDistanceCollision;
 
 template <typename Scalar>
+class ResidualDistanceCollision2Tpl;
+typedef ResidualDistanceCollision2Tpl<double> ResidualDistanceCollision2;
+template <typename Scalar>
+class ResidualDataDistanceCollision2Tpl;
+typedef ResidualDataDistanceCollision2Tpl<double>
+    ResidualDataDistanceCollision2;
+
+template <typename Scalar>
 class ResidualModelVelocityAvoidanceTpl;
 typedef ResidualModelVelocityAvoidanceTpl<double>
     ResidualModelVelocityAvoidance;
 template <typename Scalar>
 class ResidualDataVelocityAvoidanceTpl;
 typedef ResidualDataVelocityAvoidanceTpl<double> ResidualDataVelocityAvoidance;
+
+template <typename Scalar>
+class StateMultibodyTpl;
+typedef StateMultibodyTpl<double> StateMultibody;
+
+template <typename Scalar>
+class DifferentialActionModelFreeFwdDynamicsTpl;
+template <typename Scalar>
+class DifferentialActionDataFreeFwdDynamicsTpl;
+typedef DifferentialActionModelFreeFwdDynamicsTpl<double>
+    DifferentialActionModelFreeFwdDynamics;
 
 template <typename Scalar, int N>
 class ActivationModelExpTpl;

--- a/include/colmpc/multibody.hpp
+++ b/include/colmpc/multibody.hpp
@@ -1,0 +1,47 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef COLMPC_STATES_MULTIBODY_HPP_
+#define COLMPC_STATES_MULTIBODY_HPP_
+
+#include <colmpc/fwd.hpp>
+#include <pinocchio/multibody/geometry.hpp>
+
+#include "crocoddyl/multibody/states/multibody.hpp"
+
+namespace colmpc {
+
+template <typename _Scalar>
+class StateMultibodyTpl : public crocoddyl::StateMultibodyTpl<_Scalar> {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef crocoddyl::StateMultibodyTpl<Scalar> Base;
+  typedef pinocchio::GeometryModel GeometryModel;
+
+  explicit StateMultibodyTpl(
+      std::shared_ptr<typename Base::PinocchioModel> model,
+      std::shared_ptr<GeometryModel> gmodel)
+      : Base(model), geometry_(gmodel) {}
+  StateMultibodyTpl() = default;
+  virtual ~StateMultibodyTpl() = default;
+
+  const std::shared_ptr<GeometryModel> &get_geometry() const {
+    return geometry_;
+  }
+
+ private:
+  std::shared_ptr<GeometryModel> geometry_;
+};
+
+extern template class StateMultibodyTpl<double>;
+
+}  // namespace colmpc
+
+#endif  // COLMPC_STATES_MULTIBODY_HPP_

--- a/include/colmpc/python.hpp
+++ b/include/colmpc/python.hpp
@@ -14,9 +14,12 @@
 namespace colmpc {
 namespace python {
 
+void exposeStateMultibody();
+void exposeDynamicFreeFwd();
 void exposeActivationModelQuadExp();
 void exposeActivationModelDistanceQuad();
 void exposeResidualDistanceCollision();
+void exposeResidualDistanceCollision2();
 void exposeResidualVelocityAvoidance();
 
 }  // namespace python

--- a/include/colmpc/residual-distance-collision-2.hxx
+++ b/include/colmpc/residual-distance-collision-2.hxx
@@ -1,0 +1,109 @@
+// BSD 3-Clause License
+//
+// Copyright (C) 2024, LAAS-CNRS.
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+
+#ifndef COLMPC_RESIDUAL_2_HXX_
+#define COLMPC_RESIDUAL_2_HXX_
+#ifdef PINOCCHIO_WITH_HPP_FCL
+
+namespace colmpc {
+using namespace crocoddyl;
+
+template <typename Scalar>
+ResidualDistanceCollision2Tpl<Scalar>::ResidualDistanceCollision2Tpl(
+    std::shared_ptr<StateMultibody> state, const std::size_t nu,
+    const pinocchio::PairIndex pair_id)
+    : Base(state, 1, nu, true, false, false), pair_id_(pair_id) {
+  if (static_cast<pinocchio::FrameIndex>(
+          state->get_geometry()->collisionPairs.size()) <= pair_id) {
+    throw_pretty(
+        "Invalid argument: "
+        << "the pair index is wrong (it does not exist in the geometry model)");
+  }
+}
+
+template <typename Scalar>
+ResidualDistanceCollision2Tpl<Scalar>::~ResidualDistanceCollision2Tpl() {}
+
+template <typename Scalar>
+void ResidualDistanceCollision2Tpl<Scalar>::calc(
+    const std::shared_ptr<ResidualDataAbstract> &data,
+    const Eigen::Ref<const VectorXs> &x, const Eigen::Ref<const VectorXs> &) {
+  Data *d = static_cast<Data *>(data.get());
+  d->r[0] = d->geometry->distanceResults[pair_id_].min_distance;
+}
+
+template <typename Scalar>
+void ResidualDistanceCollision2Tpl<Scalar>::calcDiff(
+    const std::shared_ptr<ResidualDataAbstract> &data,
+    const Eigen::Ref<const VectorXs> &x, const Eigen::Ref<const VectorXs> &) {
+  Data *d = static_cast<Data *>(data.get());
+
+  const std::size_t nv = state_->get_nv();
+  auto state = std::static_pointer_cast<StateMultibody>(state_);
+  auto const &gmodel = state->get_geometry();
+  auto const &res = d->geometry->distanceResults[pair_id_];
+
+  const auto &cp = gmodel->collisionPairs[pair_id_];
+  const auto &geom_1 = gmodel->geometryObjects[cp.first];
+  const auto &geom_2 = gmodel->geometryObjects[cp.second];
+
+  pinocchio::getFrameJacobian(*state->get_pinocchio(), *d->pinocchio,
+                              geom_1.parentFrame,
+                              pinocchio::LOCAL_WORLD_ALIGNED, d->J1);
+
+  pinocchio::getFrameJacobian(*state->get_pinocchio(), *d->pinocchio,
+                              geom_2.parentFrame,
+                              pinocchio::LOCAL_WORLD_ALIGNED, d->J2);
+
+  // getting the nearest points belonging to the collision shapes
+  const Vector3s &cp1 = res.nearest_points[0];
+  const Vector3s &cp2 = res.nearest_points[1];
+  d->cp1 = cp1;
+  d->cp2 = cp2;
+  // Transport the jacobian of frame 1 into the jacobian associated to cp1
+  // Vector from frame 1 center to p1
+  d->f1p1 = cp1 - d->pinocchio->oMf[geom_1.parentFrame].translation();
+  d->f1Mp1.setIdentity();
+  d->f1Mp1.translation(d->f1p1);
+  // todo change me for simpler
+  d->J1 = d->f1Mp1.toActionMatrixInverse() * d->J1;
+  // Transport the jacobian of frame 2 into the jacobian associated to cp2
+  // Vector from frame 2 center to p2
+  d->f2p2 = cp2 - d->pinocchio->oMf[geom_2.parentFrame].translation();
+  d->f2Mp2.setIdentity();
+  d->f2Mp2.translation(d->f2p2);
+  d->J2 = d->f2Mp2.toActionMatrixInverse() * d->J2;
+
+  // calculate the Jacobian
+  // compute the residual derivatives
+  data->Rx.leftCols(nv) =
+      -res.normal.transpose() *
+      (d->J1.template topRows<3>() - d->J2.template topRows<3>());
+}
+template <typename Scalar>
+std::shared_ptr<ResidualDataAbstractTpl<Scalar> >
+ResidualDistanceCollision2Tpl<Scalar>::createData(
+    DataCollectorAbstract *const data) {
+  return std::allocate_shared<Data>(Eigen::aligned_allocator<Data>(), this,
+                                    data);
+}
+
+template <typename Scalar>
+pinocchio::PairIndex ResidualDistanceCollision2Tpl<Scalar>::get_pair_id()
+    const {
+  return pair_id_;
+}
+
+template <typename Scalar>
+void ResidualDistanceCollision2Tpl<Scalar>::set_pair_id(
+    const pinocchio::PairIndex pair_id) {
+  pair_id_ = pair_id;
+}
+
+}  // namespace colmpc
+
+#endif  // PINOCCHIO_WITH_HPP_FCL
+#endif  // COLMPC_RESIDUAL_2_HXX_

--- a/include/colmpc/residual-distance-collision.hxx
+++ b/include/colmpc/residual-distance-collision.hxx
@@ -15,7 +15,7 @@ using namespace crocoddyl;
 
 template <typename Scalar>
 ResidualDistanceCollisionTpl<Scalar>::ResidualDistanceCollisionTpl(
-    std::shared_ptr<StateMultibody> state, const std::size_t nu,
+    std::shared_ptr<crocoddyl::StateMultibody> state, const std::size_t nu,
     std::shared_ptr<GeometryModel> geom_model,
     const pinocchio::PairIndex pair_id)
     : Base(state, 1, nu, true, false, false),

--- a/include/colmpc/residual-velocity-avoidance.hpp
+++ b/include/colmpc/residual-velocity-avoidance.hpp
@@ -39,7 +39,7 @@ struct ResidualModelVelocityAvoidanceTpl
   typedef ResidualModelAbstractTpl<Scalar> Base;
   typedef ResidualDataVelocityAvoidanceTpl<Scalar> Data;
   typedef ResidualDataAbstractTpl<Scalar> ResidualDataAbstract;
-  typedef StateMultibodyTpl<Scalar> StateMultibody;
+  typedef crocoddyl::StateMultibodyTpl<Scalar> StateMultibody;
   typedef DataCollectorAbstractTpl<Scalar> DataCollectorAbstract;
   typedef pinocchio::GeometryModel GeometryModel;
   typedef typename MathBase::VectorXs VectorXs;
@@ -73,12 +73,11 @@ struct ResidualModelVelocityAvoidanceTpl
    * @param[in] ksi         Convergence speed coefficient
    */
 
-  ResidualModelVelocityAvoidanceTpl(std::shared_ptr<StateMultibody> state,
-                                    std::shared_ptr<GeometryModel> geom_model,
-                                    const pinocchio::PairIndex pair_id,
-                                    const Scalar di = 1.0e-2,
-                                    const Scalar ds = 1.0e-5,
-                                    const Scalar ksi = 1.0e-2);
+  ResidualModelVelocityAvoidanceTpl(
+      std::shared_ptr<crocoddyl::StateMultibody> state,
+      std::shared_ptr<GeometryModel> geom_model,
+      const pinocchio::PairIndex pair_id, const Scalar di = 1.0e-2,
+      const Scalar ds = 1.0e-5, const Scalar ksi = 1.0e-2);
   virtual ~ResidualModelVelocityAvoidanceTpl();
 
   /**
@@ -186,7 +185,7 @@ struct ResidualDataVelocityAvoidanceTpl
   typedef _Scalar Scalar;
   typedef MathBaseTpl<Scalar> MathBase;
   typedef ResidualDataAbstractTpl<Scalar> Base;
-  typedef StateMultibodyTpl<Scalar> StateMultibody;
+  typedef crocoddyl::StateMultibodyTpl<Scalar> StateMultibody;
   typedef DataCollectorAbstractTpl<Scalar> DataCollectorAbstract;
 
   typedef pinocchio::DataTpl<Scalar> PinocchioData;

--- a/include/colmpc/residual-velocity-avoidance.hxx
+++ b/include/colmpc/residual-velocity-avoidance.hxx
@@ -22,7 +22,7 @@ using namespace crocoddyl;
 
 template <typename Scalar>
 ResidualModelVelocityAvoidanceTpl<Scalar>::ResidualModelVelocityAvoidanceTpl(
-    std::shared_ptr<StateMultibody> state,
+    std::shared_ptr<crocoddyl::StateMultibody> state,
     std::shared_ptr<GeometryModel> geom_model,
     const pinocchio::PairIndex pair_id, const Scalar di, const Scalar ds,
     const Scalar ksi)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,6 +1,13 @@
 set(${PY_NAME}_SOURCES
-    main.cpp residual-distance-collision.cpp residual-velocity-avoidance.cpp
-    activation-distance-quadratic.cpp quadratic-exp.cpp)
+    main.cpp
+    residual-distance-collision.cpp
+    residual-velocity-avoidance.cpp
+    activation-distance-quadratic.cpp
+    quadratic-exp.cpp
+    free-fwddyn.cpp
+    state-multibody.cpp
+    free-fwddyn-instantiation.cpp
+    residual-distance-collision-2.cpp)
 
 add_library(${PY_NAME} SHARED ${${PY_NAME}_SOURCES})
 target_link_libraries(${PY_NAME} PUBLIC ${PROJECT_NAME} eigenpy::eigenpy)

--- a/python/free-fwddyn-instantiation.cpp
+++ b/python/free-fwddyn-instantiation.cpp
@@ -1,0 +1,9 @@
+#include <colmpc/free-fwddyn.hpp>
+#include <colmpc/free-fwddyn.hxx>
+
+namespace colmpc {
+
+template class DifferentialActionModelFreeFwdDynamicsTpl<double>;
+template class DifferentialActionDataFreeFwdDynamicsTpl<double>;
+
+}  // namespace colmpc

--- a/python/free-fwddyn.cpp
+++ b/python/free-fwddyn.cpp
@@ -1,0 +1,37 @@
+#include "colmpc/free-fwddyn.hpp"
+
+#include "colmpc/python.hpp"
+
+namespace colmpc {
+
+namespace python {
+
+namespace bp = boost::python;
+
+void exposeDynamicFreeFwd() {
+  bp::register_ptr_to_python<
+      std::shared_ptr<DifferentialActionModelFreeFwdDynamics>>();
+
+  bp::class_<DifferentialActionModelFreeFwdDynamics,
+             bp::bases<crocoddyl::DifferentialActionModelFreeFwdDynamics>>(
+      "DifferentialActionModelFreeFwdDynamics",
+      "DifferentialActionModelFreeFwdDynamics base class with collision "
+      "calculations.",
+      bp::init<
+          std::shared_ptr<StateMultibody>,
+          std::shared_ptr<crocoddyl::ActuationModelAbstract>,
+          std::shared_ptr<crocoddyl::CostModelSum>,
+          bp::optional<std::shared_ptr<crocoddyl::ConstraintModelManager>>>(
+          bp::args("self", "state", "actuation", "costs", "constraints"),
+          "Initialize the free forward-dynamics action model.\n\n"
+          ":param state: multibody state\n"
+          ":param actuation: abstract actuation model\n"
+          ":param costs: stack of cost functions\n"
+          ":param constraints: stack of constraint functions"))
+      //   .add_property("geometry",
+      //   bp::make_function(&DifferentialActionModelFreeFwdDynamics::get_geometry()))
+      ;
+}
+
+}  // namespace python
+}  // namespace colmpc

--- a/python/main.cpp
+++ b/python/main.cpp
@@ -14,8 +14,11 @@ BOOST_PYTHON_MODULE(colmpc) {
   // Enabling eigenpy support, i.e. numpy/eigen compatibility.
   eigenpy::enableEigenPy();
   eigenpy::enableEigenPySpecific<Eigen::VectorXi>();
+  colmpc::python::exposeStateMultibody();
+  colmpc::python::exposeDynamicFreeFwd();
   colmpc::python::exposeActivationModelQuadExp();
   colmpc::python::exposeResidualDistanceCollision();
+  colmpc::python::exposeResidualDistanceCollision2();
   colmpc::python::exposeResidualVelocityAvoidance();
   colmpc::python::exposeActivationModelDistanceQuad();
 }

--- a/python/residual-distance-collision-2.cpp
+++ b/python/residual-distance-collision-2.cpp
@@ -1,0 +1,115 @@
+// BSD 3-Clause License
+//
+// Copyright (C) 2024, LAAS-CNRS.
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+
+#include "colmpc/residual-distance-collision-2.hpp"
+
+#include "colmpc/python.hpp"
+
+namespace colmpc {
+namespace python {
+
+namespace bp = boost::python;
+
+void exposeResidualDistanceCollision2() {
+  bp::register_ptr_to_python<std::shared_ptr<ResidualDistanceCollision2>>();
+
+  bp::class_<ResidualDistanceCollision2, bp::bases<ResidualModelAbstract>>(
+      "ResidualDistanceCollision2",
+      bp::init<std::shared_ptr<StateMultibody>, const std::size_t,
+               const pinocchio::PairIndex>(
+          bp::args("self", "state", "nu", "pair_id"),
+          "Initialize the residual model.\n\n"
+          ":param state: State of the multibody system\n"
+          ":param nu: Dimension of the control vector\n"
+          ":param pair_id: Index of the collision pair in the geometry "
+          "model\n"))
+      //   .def("calc", &ResidualDistanceCollision2::calc,
+      //        bp::args("self", "data", "x", "u"),
+      //        "Compute the residual.\n\n"
+      //        ":param data: residual data\n"
+      //        ":param x: time-discrete state vector\n"
+      //        ":param u: time-discrete control input")
+      //   .def("calcDiff", &ResidualDistanceCollision2::calcDiff,
+      //        bp::args("self", "data", "x", "u"),
+      //        "Compute the Jacobians of the residual.\n\n"
+      //        "It assumes that calc has been run first.\n"
+      //        ":param data: action data\n"
+      //        ":param x: time-discrete state vector\n"
+      //        ":param u: time-discrete control input\n")
+      .def("createData", &ResidualDistanceCollision2::createData,
+           bp::with_custodian_and_ward_postcall<0, 2>(),
+           bp::args("self", "data"),
+           "Create the residual data.\n\n"
+           "Each residual model has its own data that needs to be allocated. "
+           "This function\n"
+           "returns the allocated data for a predefined residual.\n"
+           ":param data: shared data\n"
+           ":return residual data.")
+      .add_property(
+          "collision_pair_id",
+          bp::make_function(&ResidualDistanceCollision2::get_pair_id,
+                            bp::return_value_policy<bp::return_by_value>()),
+          bp::make_function(&ResidualDistanceCollision2::set_pair_id),
+          "reference collision pair id");
+
+  bp::register_ptr_to_python<std::shared_ptr<ResidualDataDistanceCollision2>>();
+
+  bp::class_<ResidualDataDistanceCollision2, bp::bases<ResidualDataAbstract>>(
+      "ResidualDataDistanceCollision2", "Data for vel collision residual.\n\n",
+      bp::init<ResidualDistanceCollision2*, DataCollectorAbstract*>(
+          bp::args("self", "model", "data"),
+          "Create vel collision residual data.\n\n"
+          ":param model: pair collision residual model\n"
+          ":param data: shared data")[bp::with_custodian_and_ward<
+          1, 2, bp::with_custodian_and_ward<1, 3>>()])
+      .add_property("pinocchio",
+                    bp::make_getter(&ResidualDataDistanceCollision2::pinocchio,
+                                    bp::return_internal_reference<>()),
+                    "pinocchio data")
+      .add_property("J1",
+                    bp::make_getter(&ResidualDataDistanceCollision2::J1,
+                                    bp::return_internal_reference<>()),
+                    "J1")
+      .add_property("J2",
+                    bp::make_getter(&ResidualDataDistanceCollision2::J2,
+                                    bp::return_internal_reference<>()),
+                    "J2")
+      .add_property("cp1",
+                    bp::make_getter(&ResidualDataDistanceCollision2::cp1,
+                                    bp::return_internal_reference<>()),
+                    "cp1")
+      .add_property("cp2",
+                    bp::make_getter(&ResidualDataDistanceCollision2::cp2,
+                                    bp::return_internal_reference<>()),
+                    "cp2")
+      .add_property("f1p1",
+                    bp::make_getter(&ResidualDataDistanceCollision2::f1p1,
+                                    bp::return_internal_reference<>()),
+                    "f1p1")
+      .add_property("f2p2",
+                    bp::make_getter(&ResidualDataDistanceCollision2::f2p2,
+                                    bp::return_internal_reference<>()),
+                    "f2p2")
+      .add_property("f1Mp1",
+                    bp::make_getter(&ResidualDataDistanceCollision2::f1Mp1,
+                                    bp::return_internal_reference<>()),
+                    "f1Mp1")
+      .add_property("f2Mp2",
+                    bp::make_getter(&ResidualDataDistanceCollision2::f2Mp2,
+                                    bp::return_internal_reference<>()),
+                    "f2Mp2")
+      .add_property("oMg_id_1",
+                    bp::make_getter(&ResidualDataDistanceCollision2::oMg_id_1,
+                                    bp::return_internal_reference<>()),
+                    "oMg_id_1")
+      .add_property("oMg_id_2",
+                    bp::make_getter(&ResidualDataDistanceCollision2::oMg_id_2,
+                                    bp::return_internal_reference<>()),
+                    "oMg_id_2");
+}
+
+}  // namespace python
+}  // namespace colmpc

--- a/python/residual-distance-collision.cpp
+++ b/python/residual-distance-collision.cpp
@@ -18,7 +18,7 @@ void exposeResidualDistanceCollision() {
 
   bp::class_<ResidualDistanceCollision, bp::bases<ResidualModelAbstract>>(
       "ResidualDistanceCollision",
-      bp::init<std::shared_ptr<StateMultibody>, const std::size_t,
+      bp::init<std::shared_ptr<crocoddyl::StateMultibody>, const std::size_t,
                std::shared_ptr<pinocchio::GeometryModel>,
                const pinocchio::PairIndex>(
           bp::args("self", "state", "nu", "geom_model", "pair_id"),

--- a/python/residual-velocity-avoidance.cpp
+++ b/python/residual-velocity-avoidance.cpp
@@ -18,7 +18,7 @@ void exposeResidualVelocityAvoidance() {
 
   bp::class_<ResidualModelVelocityAvoidance, bp::bases<ResidualModelAbstract>>(
       "ResidualModelVelocityAvoidance",
-      bp::init<std::shared_ptr<StateMultibody>,
+      bp::init<std::shared_ptr<crocoddyl::StateMultibody>,
                std::shared_ptr<pinocchio::GeometryModel>,
                const pinocchio::PairIndex,
                bp::optional<const double, const double, const double>>(

--- a/python/state-multibody.cpp
+++ b/python/state-multibody.cpp
@@ -1,0 +1,29 @@
+#include "colmpc/multibody.hpp"
+#include "colmpc/python.hpp"
+
+namespace colmpc {
+template class StateMultibodyTpl<double>;
+
+namespace python {
+
+namespace bp = boost::python;
+
+void exposeStateMultibody() {
+  bp::register_ptr_to_python<std::shared_ptr<StateMultibody>>();
+
+  bp::class_<StateMultibody, bp::bases<crocoddyl::StateMultibody>>(
+      "StateMultibody",
+      bp::init<std::shared_ptr<pinocchio::Model>,
+               std::shared_ptr<pinocchio::GeometryModel>>(
+          bp::args("self", "pinocchioModel", "geometryModel"),
+          "Initialize the multibody state given a Pinocchio model.\n\n"
+          ":param pinocchioModel: pinocchio model (i.e. multibody model)")
+          [bp::with_custodian_and_ward<1, 2>()])
+      .add_property(
+          "geometry",
+          bp::make_function(&StateMultibody::get_geometry,
+                            bp::return_value_policy<bp::return_by_value>()));
+}
+
+}  // namespace python
+}  // namespace colmpc


### PR DESCRIPTION
In this PR, I add
- a StateMultibody class that stores a geometry model.
- a free forward dynamics calculator for crocoddyl, that also calculates the distances for the active pairs in the geometry model.
- ResidualDistanceCollision2 that converts the calculated distances to a crocoddyl residual.

With this method, all distances are calculated at once.
- using the residual both as cost and constraint does not duplicate the distance calculation.
- with several collision pairs, the calculations are *supposed to* be more cache friendly so *supposed to* be faster, though this is to be checked in practice.